### PR TITLE
fix(overlays): typescript errors

### DIFF
--- a/.changeset/serious-candles-serve.md
+++ b/.changeset/serious-candles-serve.md
@@ -1,0 +1,5 @@
+---
+'@lion/overlays': patch
+---
+
+Fix type declaration for \_\_syncFromPopperState method.

--- a/packages/overlays/types/ArrowMixinTypes.d.ts
+++ b/packages/overlays/types/ArrowMixinTypes.d.ts
@@ -1,8 +1,7 @@
 import { Constructor } from '@open-wc/dedupe-mixin';
 import { LitElement, TemplateResult } from '@lion/core';
 import { CSSResultArray } from '@lion/core';
-import Data from 'popper.js';
-import { Options as PopperOptions } from '@popperjs/core/lib/popper';
+import { Options as PopperOptions, State } from '@popperjs/core/lib/popper';
 import { OverlayConfig } from '../types/OverlayConfig';
 
 export declare class ArrowHost {
@@ -25,7 +24,7 @@ export declare class ArrowHost {
   _getPopperArrowConfig(popperConfigToExtendFrom: Partial<PopperOptions>): Partial<PopperOptions>;
   __setupRepositionCompletePromise(): void;
   get _arrowNode(): Element | null;
-  __syncFromPopperState(data: Data): void;
+  __syncFromPopperState(data: Partial<State>): void;
 }
 
 export declare function ArrowImplementation<T extends Constructor<LitElement>>(


### PR DESCRIPTION
Corrects typescript from `@popperjs/core` for overlays package

## What I did

1. Fix types from `@popperjs/core` for overlays package
